### PR TITLE
Feat: Add logging to inference endpoint `src/deployment/main.py`, fix model config and `load_data` module.

### DIFF
--- a/DOCS/deployment.md
+++ b/DOCS/deployment.md
@@ -3,7 +3,7 @@
 - To deploy your fine-tuned model (assuming it's on Hugging Face Hub) as a REST API endpoint, follow these instructions:
 
 
-1. Set up environment variables by creating a `.env` file and add your variables like this:
+1. Navigate to `src/deployment` and set up environment variables by creating a `.env` file and add your variables like this:
 ```python
 MODEL_NAME = "your-model-name"
 HUGGINGFACE_READ_TOKEN = "your-token"

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ uvicorn main:app --host 0.0.0.0 --port 8000
 
 - Test it out by accessing the Swagger UI at `http://localhost:8000/docs` and uploading either an .mp3 file or a .wav file and a task either `transcribe` or `translate`. Alternatively, you can use Postman with the URL `http://localhost:8000/speechinference`.
 
-## Deployment
+## 🛳️ Deployment
 
 - To deploy your fine-tuned model (assuming it's on Hugging Face Hub) as a REST API endpoint, follow these [instructions](https://github.com/KevKibe/African-Whisper/blob/master/DOCS/DEPLOYMENT.md).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ yt-dlp==2023.11.14
 ctranslate2==4.1.0
 fastapi[all]
 uvicorn[standard]
+python-dotenv==1.0.1
+logging==0.4.9.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ install_requires =
     scipy==1.12.0
     tensorflow-probability==0.24.0
     yt-dlp==2023.11.14
+    python-dotenv==1.0.1
+    logging==0.4.9.6
 package_dir=
     =src
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = africanwhisper
 author = Kevin Kibe
-version = 0.3.0
+version = 0.4.0
 author_email = keviinkibe@gmail.com
 description = A package for fast fine-tuning and API endpoint deployment of Whisper model specifically developed to accelerate Automatic Speech Recognition(ASR) for African Languages.
 long_description = file: README.md

--- a/src/deployment/main.py
+++ b/src/deployment/main.py
@@ -3,7 +3,10 @@ from fastapi import FastAPI, UploadFile, HTTPException
 from pydantic import BaseModel
 import tempfile
 from speech_inference import SpeechInference
-
+import logging
+import time
+from dotenv import load_dotenv
+load_dotenv()
 
 app = FastAPI()
 
@@ -19,9 +22,13 @@ class AudioTranscriptionRequest(BaseModel):
     task: str
 
 
+
 @app.post("/speech_inference")
 async def speechinference(file: UploadFile, task: str):
+    logger = logging.getLogger(__name__)
+    logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s', filename='app.log', level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
     if file is None:
+        logger.error("No file provided")
         raise HTTPException(status_code=400, detail="No file provided")
 
     try:
@@ -30,13 +37,22 @@ async def speechinference(file: UploadFile, task: str):
             tmp_file_path = tmp_file.name
 
         if file.filename.endswith(".mp3"):
+            logger.info("Processing mp3 file")
+            start_time = time.time()
             result = inference.output(pipeline, tmp_file_path, task)
+            end_time = time.time()
+            logger.info(f"Time taken for inference: {end_time - start_time} seconds")
         elif file.filename.endswith(".wav"):
+            logger.info("Processing wav file")
             pass
         else:
+            logger.error("Unsupported file format")
             raise HTTPException(status_code=400, detail="Unsupported file format")
 
+        logger.info("File processed successfully")
         return result
     except Exception as e:
+        logger.error(f"Error processing file: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error processing file: {str(e)}")
+
 

--- a/src/deployment/speech_inference.py
+++ b/src/deployment/speech_inference.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import pipeline, AutomaticSpeechRecognitionPipeline
+from transformers import pipeline, AutomaticSpeechRecognitionPipeline, AutoModelForSpeechSeq2Seq, AutoProcessor
 from typing import List, Tuple, Any, Dict
 from pydantic import BaseModel, Field
 
@@ -67,16 +67,20 @@ class SpeechInference:
             print("No audio file submitted! Please upload or record an audio file before submitting your request.")
         else:
             device = 0 if torch.cuda.is_available() else "cpu"
-            if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
-                dtype = torch.bfloat16
-            else:
-                dtype = None
+            torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32
+        model = AutoModelForSpeechSeq2Seq.from_pretrained(
+        self.model_name , torch_dtype=torch_dtype, low_cpu_mem_usage=True, use_safetensors=True
+        )
+        model.to(device)
+        processor = AutoProcessor.from_pretrained(self.model_name)
         pipe = pipeline(
-                            task="automatic-speech-recognition",
-                            model=self.model_name,
-                            token=self.huggingface_read_token,
-                            device=device,
-                            torch_dtype=dtype
+                        task="automatic-speech-recognition",
+                        model=model,
+                        tokenizer=processor.tokenizer,
+                        feature_extractor=processor.feature_extractor,
+                        token=self.huggingface_read_token,
+                        device=device,
+                        torch_dtype=torch_dtype
                         )
         return pipe
     
@@ -99,7 +103,7 @@ class SpeechInference:
                 return_timestamps=True,
                 generate_kwargs={"task": task}
             )
-        transcription = Transcription(**transcription)
+        # transcription = Transcription(**transcription)
         return transcription
 
 

--- a/src/training/load_data.py
+++ b/src/training/load_data.py
@@ -71,7 +71,7 @@ class Dataset:
                                     trust_remote_code=True)
         dataset['train'] = interleave_datasets([dataset_ti['train'], dataset_yi['train']])
         dataset['test'] = interleave_datasets([dataset_ti['test'], dataset_yi['test']])
-    #     return dataset
+        return dataset
     
     # def load_dataset(self) -> DatasetDict:
     #     """

--- a/src/training/load_data.py
+++ b/src/training/load_data.py
@@ -28,25 +28,6 @@ class Dataset:
         self.language_abbr = language_abbr
 
 
-    # def load_dataset(self) -> DatasetDict:
-    #     """
-    #     Load the streaming dataset.
-
-    #     Args:
-    #         split (Optional[str]): The dataset split to load. Defaults to 'train'.
-    #         **kwargs: Additional keyword arguments.
-
-    #     Returns:
-    #         DatasetDict: The loaded streaming dataset.
-    #     """
-    #     dataset = DatasetDict()
-    #     dataset['test'] = load_dataset(self.dataset_name, self.language_abbr, split="test", 
-    #                                         token=self.huggingface_token, streaming=True, 
-    #                                         trust_remote_code=True)
-    #     dataset['train'] = load_dataset(self.dataset_name, self.language_abbr, split="train", 
-    #                                         token=self.huggingface_token, streaming=True, 
-    #                                         trust_remote_code=True)
-        # return dataset
     def load_dataset(self) -> DatasetDict:
         """
         Load the streaming dataset.
@@ -59,41 +40,13 @@ class Dataset:
             DatasetDict: The loaded streaming dataset.
         """
         dataset = DatasetDict()
-
-        # Load English dataset
-        dataset_ti = load_dataset(self.dataset_name, "ti", 
-                                    token=self.huggingface_token, streaming=True, 
-                                    trust_remote_code=True)
-
-        # Load Swahili dataset
-        dataset_yi= load_dataset(self.dataset_name, "af", 
-                                    token=self.huggingface_token, streaming=True, 
-                                    trust_remote_code=True)
-        dataset['train'] = interleave_datasets([dataset_ti['train'], dataset_yi['train']])
-        dataset['test'] = interleave_datasets([dataset_ti['test'], dataset_yi['test']])
+        dataset['test'] = load_dataset(self.dataset_name, self.language_abbr, split="test", 
+                                            token=self.huggingface_token, streaming=True, 
+                                            trust_remote_code=True)
+        dataset['train'] = load_dataset(self.dataset_name, self.language_abbr, split="train", 
+                                            token=self.huggingface_token, streaming=True, 
+                                            trust_remote_code=True)
         return dataset
-    
-    # def load_dataset(self) -> DatasetDict:
-    #     """
-    #     Load the streaming dataset for the specified language(s).
-
-    #     Returns:
-    #         DatasetDict: The loaded streaming dataset.
-    #     """
-    #     dataset = DatasetDict()
-
-    #     for lang in self.language_abbr:
-    #         lang_dataset = load_dataset(self.dataset_name, lang,
-    #                                     token=self.huggingface_token, streaming=True,
-    #                                     trust_remote_code=True)
-    #         if 'train' not in dataset:
-    #             dataset['train'] = lang_dataset['train']
-    #             dataset['test'] = lang_dataset['test']
-    #         else:
-    #             dataset['train'] = interleave_datasets([dataset['train'], lang_dataset['train']])
-    #             dataset['test'] = interleave_datasets([dataset['test'], lang_dataset['test']])
-
-    #     return dataset
         
     def count_examples(self, dataset: IterableDataset) -> int:
         """

--- a/src/training/load_data.py
+++ b/src/training/load_data.py
@@ -1,4 +1,4 @@
-from datasets import load_dataset, DatasetDict, IterableDataset, interleave_datasets
+from datasets import load_dataset, DatasetDict, IterableDataset
 import warnings
 from typing import List
 

--- a/src/training/model_trainer.py
+++ b/src/training/model_trainer.py
@@ -185,7 +185,8 @@ class Trainer:
         processor = model_prep.initialize_processor()
         tokenizer.save_pretrained(training_args.output_dir)
         processor.save_pretrained(training_args.output_dir)
-        torch.save(self.model.state_dict(), f"{training_args.output_dir}/pytorch_model.bin")
+        # torch.save(self.model.state_dict(), f"{training_args.output_dir}/pytorch_model.bin")
+        self.model.save_pretrained(training_args.output_dir)
         progress_callback = WandbProgressResultsCallback(
             trainer, eval_dataset, tokenizer
         )

--- a/src/training/whisper_model_prep.py
+++ b/src/training/whisper_model_prep.py
@@ -101,7 +101,7 @@ class WhisperModelPrep:
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []
             model.generation_config.language = "en"
-            model.generation_config.task = "automatic-speech-recognition"
+            model.generation_config.task = "translate"
             model = prepare_model_for_kbit_training(model)
             config = LoraConfig(
                 r=32,
@@ -120,6 +120,6 @@ class WhisperModelPrep:
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []
             model.generation_config.language = "en"
-            model.generation_config.task = "automatic-speech-recognition"
+            model.generation_config.task = "translate"
 
         return model

--- a/src/training/whisper_model_prep.py
+++ b/src/training/whisper_model_prep.py
@@ -100,7 +100,7 @@ class WhisperModelPrep:
             )
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []
-            model.generation_config.language = f"{self.language_abbr}"
+            model.generation_config.language = "en"
             model.generation_config.task = "translate"
             model = prepare_model_for_kbit_training(model)
             config = LoraConfig(
@@ -119,6 +119,6 @@ class WhisperModelPrep:
             )
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []
-            model.generation_config.language = f"{self.language_abbr}"
+            model.generation_config.language = "en"
             model.generation_config.task = "translate"
         return model

--- a/src/training/whisper_model_prep.py
+++ b/src/training/whisper_model_prep.py
@@ -50,7 +50,7 @@ class WhisperModelPrep:
 
         """
         return WhisperFeatureExtractor.from_pretrained(
-            self.model_id, cache_dir=f"./{self.language_abbr}/feature-extractor"
+            self.model_id
         )
 
     def initialize_tokenizer(self) -> WhisperTokenizer:
@@ -62,7 +62,7 @@ class WhisperModelPrep:
 
         """
         return WhisperTokenizer.from_pretrained(
-            self.model_id, cache_dir=f"./{self.language_abbr}/tokenizer"
+            self.model_id
         )
 
     def initialize_processor(self) -> WhisperProcessor:
@@ -94,7 +94,7 @@ class WhisperModelPrep:
         if self.use_peft:
             model = WhisperForConditionalGeneration.from_pretrained(
                 self.model_id,
-                cache_dir=f"./{self.language_abbr}/model",
+                # cache_dir="./whisper-model/model",
                 load_in_8bit=True,
                 device_map="auto",
             )
@@ -115,7 +115,7 @@ class WhisperModelPrep:
         else:
             print("PEFT optimization is not enabled.")
             model = WhisperForConditionalGeneration.from_pretrained(
-                self.model_id, cache_dir=f"./{self.language_abbr}/model"
+                self.model_id
             )
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []

--- a/src/training/whisper_model_prep.py
+++ b/src/training/whisper_model_prep.py
@@ -101,7 +101,7 @@ class WhisperModelPrep:
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []
             model.generation_config.language = "en"
-            model.generation_config.task = "translate"
+            model.generation_config.task = "transcribe"
             model = prepare_model_for_kbit_training(model)
             config = LoraConfig(
                 r=32,
@@ -120,5 +120,6 @@ class WhisperModelPrep:
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []
             model.generation_config.language = "en"
-            model.generation_config.task = "translate"
+            model.generation_config.task = "transcribe"
+
         return model

--- a/src/training/whisper_model_prep.py
+++ b/src/training/whisper_model_prep.py
@@ -101,7 +101,7 @@ class WhisperModelPrep:
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []
             model.generation_config.language = "en"
-            model.generation_config.task = "transcribe"
+            model.generation_config.task = "automatic-speech-recognition"
             model = prepare_model_for_kbit_training(model)
             config = LoraConfig(
                 r=32,
@@ -120,6 +120,6 @@ class WhisperModelPrep:
             model.config.forced_decoder_ids = None
             model.config.suppress_tokens = []
             model.generation_config.language = "en"
-            model.generation_config.task = "transcribe"
+            model.generation_config.task = "automatic-speech-recognition"
 
         return model


### PR DESCRIPTION
- Logging to inference endpoint `src/deployment/main.py` .
- Refactored `model.generation_config.language` to `en`.
- `model` and `processor` loaded from `AutoModelForSpeechSeq2Seq` and `AutoProcessor` respectively in `src/deployment/speech_inference.py`
- `src/training/load_data.py` back to as it was loading a dataset from one language.